### PR TITLE
Fix incorrect use of serverVersion for MariaDB

### DIFF
--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -60,7 +60,7 @@ function mapPlatformShDatabase() : void
                 switch ($endpoint['scheme']) {
                     case 'mysql':
                         // Defaults to the latest MariaDB version
-                        $dbUrl .= '?charset=utf8mb4&serverVersion=10.2';
+                        $dbUrl .= '?charset=utf8mb4&serverVersion=mariadb-10.2.12';
                         break;
 
                     case 'pgsql':


### PR DESCRIPTION
This small change fixes 2 critical things:

1/ Incorrect use of `serverVersion` for MariaDB, which *must* be prefixed with `mariadb-`, see: https://github.com/doctrine/dbal/pull/3083 && https://github.com/symfony/symfony-docs/pull/9547 (and https://github.com/doctrine/dbal/issues/2985#issuecomment-378595588 for the discussion)

2/ `doctrine/dbal` now supports `MariaDB >= 10.2.7`. I added the `.12` as a minor version, but we don't need to update it when platform.sh will use .13 or .14 etc.... as long as it's superior as `10.2.7` (see: https://github.com/doctrine/dbal/blob/f76bf5ef631cec551a86c2291fc749534febebf1/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php#L136)