### PR TITLE
Use database type env exposure to dynamically set the DB type for Doctrine.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
             "email": "larry@platform.sh"
         }
     ],
-    "require": {},
+    "require": {
+        "php": "^7.1"
+    },
     "autoload": {
         "files": ["platformsh-flex-env.php"]
     },

--- a/tests/FlexBridgeDatabaseTest.php
+++ b/tests/FlexBridgeDatabaseTest.php
@@ -7,9 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class FlexBridgeDatabaseTest extends TestCase
 {
-
     protected $relationships;
-
     protected $defaultDbUrl;
 
     public function setUp()
@@ -26,12 +24,13 @@ class FlexBridgeDatabaseTest extends TestCase
                     'port' => '3306',
                     'path' => 'main',
                     'query' => ['is_master' => true],
+                    'type' => 'mysql:10.2'
                 ]
             ]
         ];
 
         $this->defaultDbUrl = sprintf(
-            '%s://%s:%s@%s:%s/%s?charset=utf8mb4&serverVersion=10.2',
+            '%s://%s:%s@%s:%s/%s?charset=utf8mb4&serverVersion=mariadb-10.2.12',
             'mysql',
             '',
             '',
@@ -82,7 +81,6 @@ class FlexBridgeDatabaseTest extends TestCase
         putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($this->relationships))));
 
         mapPlatformShEnvironment();
-
         $this->assertEquals('mysql://user:@database.internal:3306/main?charset=utf8mb4&serverVersion=mariadb-10.2.12', $_SERVER['DATABASE_URL']);
     }
 


### PR DESCRIPTION
PostgreSQL latest version on platform.sh is version 11. [Source](https://docs.platform.sh/configuration/services/postgresql.html).

It seems a little bit weird to hardcode this value when we can access it through `PLATFORM_RELATIONSHIPS` 

Edit: example of the algorithm: https://3v4l.org/q70OT
