### PR TITLE
Implements Doctrine-odm-bundle configuration

### DIFF
--- a/tests/FlexBridgeMongoDatabaseTest.php
+++ b/tests/FlexBridgeMongoDatabaseTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Platformsh\FlexBridge\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+use function Platformsh\FlexBridge\mapPlatformShEnvironment;
+
+class FlexBridgeMongoDatabaseTest extends TestCase
+{
+    protected $relationships;
+    protected $defaultValues;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->relationships = [
+            'mongodatabase' => [
+                [
+                    'scheme'   => 'mongodb',
+                    'username' => 'main_username',
+                    'password' => 'main_password',
+                    'host'     => 'mongodatabase.internal',
+                    'port'     => 27017,
+                    'path'     => 'main',
+                    'query'    => ['is_master' => true],
+                ]
+            ]
+        ];
+
+        $this->defaultValues = [];
+
+    }
+
+    public function testNotOnPlatformshDoesNotSetDatabase(): void
+    {
+        mapPlatformShEnvironment();
+
+        $this->assertArrayNotHasKey('MONGODB_SERVER', $_SERVER);
+        $this->assertArrayNotHasKey('MONGODB_DB', $_SERVER);
+        $this->assertArrayNotHasKey('MONGODB_USERNAME', $_SERVER);
+        $this->assertArrayNotHasKey('MONGODB_PASSWORD', $_SERVER);
+    }
+
+    public function testNoDatabaseRelationship(): void
+    {
+        putenv('PLATFORM_APPLICATION=test');
+
+        $rels = $this->relationships;
+        unset($rels['mongodatabase']);
+
+        putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($rels))));
+
+        mapPlatformShEnvironment();
+
+        $this->assertArrayNotHasKey('MONGODB_SERVER', $_SERVER);
+        $this->assertArrayNotHasKey('MONGODB_DB', $_SERVER);
+        $this->assertArrayNotHasKey('MONGODB_USERNAME', $_SERVER);
+        $this->assertArrayNotHasKey('MONGODB_PASSWORD', $_SERVER);
+    }
+
+    public function testDatabaseRelationshipSet(): void
+    {
+        putenv('PLATFORM_APPLICATION=test');
+        putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($this->relationships))));
+
+        mapPlatformShEnvironment();
+
+        $this->assertEquals('mongodb://mongodatabase.internal:27017', $_SERVER['MONGODB_SERVER']);
+        $this->assertEquals('main', $_SERVER['MONGODB_DB']);
+        $this->assertEquals('main_username', $_SERVER['MONGODB_USERNAME']);
+        $this->assertEquals('main_password', $_SERVER['MONGODB_PASSWORD']);
+    }
+}


### PR DESCRIPTION
 Set the MONGODB_SERVER, MONGODB_DB, MONGODB_USERNAME, and MONGODB_PASSWORD for Doctrine, if necessary.

Full DSN using 1 string does not work so we need those 4 env variables.
Symfony Config will be:
```yaml
    doctrine_mongodb:
        connections:
            default:
                server: '%env(MONGODB_SERVER)%'
                options: { username: '%env(MONGODB_USERNAME)%', password: '%env(MONGODB_PASSWORD)%', authSource: '%env(MONGODB_DB)%' }
        default_database: '%env(MONGODB_DB)%'
```

See: https://symfony.com/doc/master/bundles/DoctrineMongoDBBundle/index.html