### PR TITLE
Update the bridge to use the Config Reader library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "platformsh/config-reader": "dev-master"
+        "platformsh/config-reader": "^2.1.0"
     },
     "autoload": {
         "files": ["platformsh-flex-env.php"]

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "platformsh/config-reader": "dev-master"
     },
     "autoload": {
         "files": ["platformsh-flex-env.php"]
@@ -26,6 +27,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.4"
     }
 }

--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -20,7 +20,7 @@ function mapPlatformShEnvironment() : void
 {
     // If this env var is not set then we're not on a Platform.sh
     // environment or in the build hook, so don't try to do anything.
-    if (!getenv('PLATFORM_APPLICATION')) {
+    if (!getenv('PLATFORM_APPLICATION_NAME')) {
         return;
     }
 

--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -45,9 +45,9 @@ function mapPlatformShEnvironment() : void
     if (!getenv('DATABASE_URL')) {
         setEnvVar('DATABASE_URL', mapPlatformShDatabase());
     }
-    if (!getenv('MONGO_SERVER')) {
-        mapPlatformShMongoDatabase();
-    }
+
+    mapPlatformShMongoDatabase('mongodatabase', $config);
+
     if (!getenv('MAILER_URL')) {
         setEnvVar('MAILER_URL', mapPlatformShSwiftmailer());
     }
@@ -197,21 +197,16 @@ function setDefaultDoctrineUrl()
  *
  * For more information: https://symfony.com/doc/master/bundles/DoctrineMongoDBBundle/index.html
  */
-function mapPlatformShMongoDatabase(): void
+function mapPlatformShMongoDatabase(string $relationshipName, Config $config): void
 {
-    $dbRelationshipName = 'mongodatabase';
-
-    if (getenv('PLATFORM_RELATIONSHIPS')) {
-        $relationships = json_decode(base64_decode(getenv('PLATFORM_RELATIONSHIPS'), true), true);
-        if (isset($relationships[$dbRelationshipName])) {
-            foreach ($relationships[$dbRelationshipName] as $endpoint) {
-                if (!empty($endpoint['query']['is_master'])) {
-                    setEnvVar('MONGODB_SERVER', sprintf('mongodb://%s:%d', $endpoint['host'], $endpoint['port']));
-                    setEnvVar('MONGODB_DB', $endpoint['path']);
-                    setEnvVar('MONGODB_USERNAME', $endpoint['username']);
-                    setEnvVar('MONGODB_PASSWORD', $endpoint['password']);
-                }
-            }
-        }
+    if (!$config->hasRelationship($relationshipName)) {
+        return;
     }
+
+    $credentials = $config->credentials($relationshipName);
+
+    setEnvVar('MONGODB_SERVER', sprintf('mongodb://%s:%d', $credentials['host'], $credentials['port']));
+    setEnvVar('MONGODB_DB', $credentials['path']);
+    setEnvVar('MONGODB_USERNAME', $credentials['username']);
+    setEnvVar('MONGODB_PASSWORD', $credentials['password']);
 }

--- a/tests/FlexBridgeDatabaseTest.php
+++ b/tests/FlexBridgeDatabaseTest.php
@@ -51,10 +51,9 @@ class FlexBridgeDatabaseTest extends TestCase
 
     public function testNoRelationships() : void
     {
-        // We assume no relationships array, but a PLATFORM_APPLICATION env var,
-        // means we're in a build hook.
+        // Application name but no environment name means build hook.
 
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
 
         //putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($this->relationships))));
 
@@ -65,7 +64,8 @@ class FlexBridgeDatabaseTest extends TestCase
 
     public function testNoDatabaseRelationship() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
 
         $rels = $this->relationships;
         unset($rels['database']);
@@ -79,7 +79,8 @@ class FlexBridgeDatabaseTest extends TestCase
 
     public function testDatabaseRelationshipSet() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
         putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($this->relationships))));
 
         mapPlatformShEnvironment();
@@ -88,7 +89,8 @@ class FlexBridgeDatabaseTest extends TestCase
 
     public function testDatabaseRelationshipOnFoundation1() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
 
         $rels = $this->relationships;
 

--- a/tests/FlexBridgeDatabaseTest.php
+++ b/tests/FlexBridgeDatabaseTest.php
@@ -49,7 +49,7 @@ class FlexBridgeDatabaseTest extends TestCase
         $this->assertArrayNotHasKey('DATABASE_URL', $_SERVER);
     }
 
-    public function testNoRelationships() : void
+    public function testNoRelationshipsBecauseBuild() : void
     {
         // Application name but no environment name means build hook.
 
@@ -62,7 +62,7 @@ class FlexBridgeDatabaseTest extends TestCase
         $this->assertEquals($this->defaultDbUrl, $_SERVER['DATABASE_URL']);
     }
 
-    public function testNoDatabaseRelationship() : void
+    public function testNoDatabaseRelationshipInRuntime() : void
     {
         putenv('PLATFORM_APPLICATION_NAME=test');
         putenv('PLATFORM_ENVIRONMENT=test');
@@ -74,7 +74,7 @@ class FlexBridgeDatabaseTest extends TestCase
 
         mapPlatformShEnvironment();
 
-        $this->assertEquals($this->defaultDbUrl, $_SERVER['DATABASE_URL']);
+        $this->assertArrayNotHasKey('DATABASE_URL', $_SERVER);
     }
 
     public function testDatabaseRelationshipSet() : void

--- a/tests/FlexBridgeMongoDatabaseTest.php
+++ b/tests/FlexBridgeMongoDatabaseTest.php
@@ -46,7 +46,8 @@ class FlexBridgeMongoDatabaseTest extends TestCase
 
     public function testNoDatabaseRelationship(): void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
 
         $rels = $this->relationships;
         unset($rels['mongodatabase']);
@@ -63,7 +64,8 @@ class FlexBridgeMongoDatabaseTest extends TestCase
 
     public function testDatabaseRelationshipSet(): void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
         putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($this->relationships))));
 
         mapPlatformShEnvironment();

--- a/tests/FlexBridgeTest.php
+++ b/tests/FlexBridgeTest.php
@@ -19,7 +19,8 @@ class FlexBridgeTest extends TestCase
 
     public function testSetAppSecret() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
         putenv('PLATFORM_PROJECT_ENTROPY=test');
 
         mapPlatformShEnvironment();
@@ -30,7 +31,8 @@ class FlexBridgeTest extends TestCase
 
     public function testDontChangeAppSecret() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
         putenv('PLATFORM_PROJECT_ENTROPY=test');
         putenv('APP_SECRET=original');
 
@@ -42,7 +44,8 @@ class FlexBridgeTest extends TestCase
 
     public function testAppEnvAlreadySetInServer() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
         putenv('APP_ENV=dev');
 
         mapPlatformShEnvironment();
@@ -53,7 +56,8 @@ class FlexBridgeTest extends TestCase
 
     public function testAppEnvAlreadySetInEnv() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
         putenv('APP_ENV=dev');
 
         mapPlatformShEnvironment();
@@ -64,7 +68,8 @@ class FlexBridgeTest extends TestCase
 
     public function testAppEnvNeedsDefault() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
 
         mapPlatformShEnvironment();
 
@@ -74,7 +79,8 @@ class FlexBridgeTest extends TestCase
 
     public function testSwiftmailer() : void
     {
-        putenv('PLATFORM_APPLICATION=test');
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
         putenv('PLATFORM_SMTP_HOST=1.2.3.4');
 
         mapPlatformShEnvironment();


### PR DESCRIPTION
Do not merge until the new config reader library is tagged and the composer.json here updated.

Question: Should the Doctrine formatter move to the config reader library or is it fine here?  Doctrine's main user is Symfony AFAIK, so I don't know if the configuration is the same elsewhere.