### PR TITLE
#20 - Fallback to NULL mail transport protocol if disabled

### DIFF
--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -83,8 +83,8 @@ function mapPlatformShSwiftmailer(Config $config)
 {
     $mailUrl = sprintf(
         '%s://%s:%d/',
-        'smtp',
-        $config->smtpHost,
+        $config->smtpHost ? 'smtp' : 'null',
+        $config->smtpHost ?: 'localhost',
         25
     );
 

--- a/tests/FlexBridgeTest.php
+++ b/tests/FlexBridgeTest.php
@@ -89,4 +89,15 @@ class FlexBridgeTest extends TestCase
         $this->assertEquals('smtp://1.2.3.4:25/', getenv('MAILER_URL'));
     }
 
+    public function testSwiftmailerDisabledMail() : void
+    {
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
+        putenv('PLATFORM_SMTP_HOST=');
+
+        mapPlatformShEnvironment();
+
+        $this->assertEquals('null://localhost:25/', $_SERVER['MAILER_URL']);
+        $this->assertEquals('null://localhost:25/', getenv('MAILER_URL'));
+    }
 }


### PR DESCRIPTION
Avoid setting an invalid `MAILER_URL` if sending mails is disabled. Use the `NULL` transport protocol instead and fallback the host to `localhost`.

`smtp://:25` --> `null://localhost:25`