### PR TITLE
Fix access to smtpHost config variable if not present

### DIFF
--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -83,8 +83,8 @@ function mapPlatformShSwiftmailer(Config $config)
 {
     $mailUrl = sprintf(
         '%s://%s:%d/',
-        $config->smtpHost ? 'smtp' : 'null',
-        $config->smtpHost ?: 'localhost',
+        !empty($config->smtpHost) ? 'smtp' : 'null',
+        !empty($config->smtpHost) ? $config->smtpHost : 'localhost',
         25
     );
 

--- a/tests/FlexBridgeTest.php
+++ b/tests/FlexBridgeTest.php
@@ -99,12 +99,24 @@ class FlexBridgeTest extends TestCase
         $this->assertEquals('smtp://1.2.3.4:25/', getenv('MAILER_URL'));
     }
 
-    public function testSwiftmailerDisabledMail() : void
+    public function testSwiftmailerDisabledMailEnvVarEmpty() : void
     {
         putenv('PLATFORM_APPLICATION_NAME=test');
         putenv('PLATFORM_ENVIRONMENT=test');
         putenv('PLATFORM_PROJECT_ENTROPY=test');
         putenv('PLATFORM_SMTP_HOST=');
+
+        mapPlatformShEnvironment();
+
+        $this->assertEquals('null://localhost:25/', $_SERVER['MAILER_URL']);
+        $this->assertEquals('null://localhost:25/', getenv('MAILER_URL'));
+    }
+
+    public function testSwiftmailerDisabledMailEnvVarNotDefined() : void
+    {
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
+        putenv('PLATFORM_PROJECT_ENTROPY=test');
 
         mapPlatformShEnvironment();
 


### PR DESCRIPTION
Check with isset first, with doesn't throw the exception. Null coalescing operator calls `__isset`.

resolves #23