### PR TITLE
Revise database version handling

### DIFF
--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -129,7 +129,7 @@ function doctrineFormatter(array $credentials) : string
             $dbVersion = (false !== $versionPosition) ? substr($type, $versionPosition + 1) : '10.2';
 
             // Doctrine needs the mariadb-prefix if it's an instance of MariaDB server
-            if ($dbVersion !== '5.5') {
+            if ($dbVersion !== '5.5' && $dbVersion !== '5.7' && $dbVersion !== '8.0') {
                 $dbVersion = sprintf('mariadb-%s', $dbVersion);
             }
 

--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Platformsh\FlexBridge;
 
 use Platformsh\ConfigReader\Config;
-const DEFAULT_MYSQL_ENDPOINT_TYPE = 'mysql:10.2';
 
-const DEFAULT_POSTGRESQL_ENDPOINT_TYPE = 'postgresql:9.6';
+// These are only for the Foundation 1.x regions. If you are using some other version
+// please move to a newer region, where these values will not be needed.
+const DEFAULT_MARIADB_VERSION = '10.2';
+const DEFAULT_MYSQL_VERSION = '8.0';
+const DEFAULT_POSTGRESQL_VERSION = '9.6';
 
 mapPlatformShEnvironment();
 
@@ -108,6 +111,15 @@ function mapPlatformShMailer(Config $config)
     setEnvVar('MAILER_DSN', $mailUrl);
 }
 
+/**
+ * Formatter for Doctrine's DB URL format.
+ *
+ * Note that non-default DB versions are not supported on Foundation 1 regions.
+ * On those regions we cannot derive the version from the credential information
+ * so the hard-coded defaults defined at the top of the file are used. To use a
+ * different version of MariaDB or PostgreSQL, or to use Oracle MySQL at all,
+ * move to a Foundation 3 region.
+ */
 function doctrineFormatter(array $credentials) : string
 {
     $dbUrl = sprintf(
@@ -120,37 +132,53 @@ function doctrineFormatter(array $credentials) : string
         $credentials['path']
     );
 
-    switch ($credentials['scheme']) {
-        case 'mysql':
-            $type = $credentials['type'] ?? DEFAULT_MYSQL_ENDPOINT_TYPE;
-            $versionPosition = strpos($type, ":");
-
-            // If a version is found, use it, otherwise, default to mariadb 10.2.
-            $dbVersion = (false !== $versionPosition) ? substr($type, $versionPosition + 1) : '10.2';
-
-            // Doctrine needs the mariadb-prefix if it's an instance of MariaDB server
-            if (! in_array($dbVersion, ['5.5', '5.7', '8.0'])) {
-                $dbVersion = sprintf('mariadb-%s', $dbVersion);
-            }
-
-            // if MariaDB is in version 10.2, doctrine needs to know it's superior to patch version 6 to work properly
-            if ($dbVersion === 'mariadb-10.2') {
-                $dbVersion .= '.12';
-            }
-
-            $dbUrl .= sprintf('?charset=utf8mb4&serverVersion=%s', $dbVersion);
-            break;
-        case 'pgsql':
-            $type = $credentials['type'] ?? DEFAULT_POSTGRESQL_ENDPOINT_TYPE;
-            $versionPosition = strpos($type, ":");
-
-            $dbVersion = (false !== $versionPosition) ? substr($type, $versionPosition + 1) : '11';
-            $dbUrl .= sprintf('?serverVersion=%s', $dbVersion);
-            break;
+    if (isset($credentials['type'])) {
+        list($type, $version) = explode(':', $credentials['type']);
+    }
+    else {
+        $type = $credentials['scheme'];
+        $version = null;
     }
 
-    return $dbUrl;
+    // "mysql" is an alias for MariaDB, so use the same mapper for both.
+    $mappers['mysql'] = __NAMESPACE__ . '\doctrineFormatterMariaDB';
+    $mappers['mariadb'] = __NAMESPACE__ . '\doctrineFormatterMariaDB';
+    $mappers['oracle-mysql'] = __NAMESPACE__ . '\doctrineFormatterOracleMySQL';
+    // The "Scheme" is pgsql, while the type is postgresql. Both end up in the same place.
+    $mappers['pgsql'] = __NAMESPACE__ . '\doctrineFormatterPostgreSQL';
+    $mappers['postgresql'] = __NAMESPACE__ . '\doctrineFormatterPostgreSQL';
 
+    // Add a query suffix that is appropriate to the specific DB type to handle version information.
+    return $dbUrl . $mappers[$type]($version);
+}
+
+function doctrineFormatterMariaDB(?string $version) : string
+{
+    $version = $version ?? DEFAULT_MARIADB_VERSION;
+
+    $version = sprintf('mariadb-%s', $version);
+
+    // Doctrine requires a full version number, even though it doesn't really matter what the patch version is,
+    // except for MariaDB 10.2, where it needs a verison greater than 10.2.6 to avoid certain bugs.
+    $version .= ($version === 'mariadb-10.2') ? '.12' : '.0';
+
+    return sprintf('?charset=utf8mb4&serverVersion=%s', $version);
+}
+
+function doctrineFormatterOracleMySQL(?string $version) : string
+{
+    $version = $version ?? DEFAULT_MYSQL_VERSION;
+
+    return sprintf('?charset=utf8mb4&serverVersion=%s', $version);
+}
+
+function doctrineFormatterPostgreSQL(?string $version) : string
+{
+    $version = $version ?? DEFAULT_POSTGRESQL_VERSION;
+
+    $suffix = sprintf('?serverVersion=%s', $version);
+
+    return $suffix;
 }
 
 /**

--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -129,7 +129,7 @@ function doctrineFormatter(array $credentials) : string
             $dbVersion = (false !== $versionPosition) ? substr($type, $versionPosition + 1) : '10.2';
 
             // Doctrine needs the mariadb-prefix if it's an instance of MariaDB server
-            if ($dbVersion !== '5.5' && $dbVersion !== '5.7' && $dbVersion !== '8.0') {
+            if (! in_array($dbVersion, ['5.5', '5.7', '8.0'])) {
                 $dbVersion = sprintf('mariadb-%s', $dbVersion);
             }
 

--- a/tests/FlexBridgeDatabaseTest.php
+++ b/tests/FlexBridgeDatabaseTest.php
@@ -6,6 +6,9 @@ namespace Platformsh\FlexBridge\Tests;
 use PHPUnit\Framework\TestCase;
 
 use function Platformsh\FlexBridge\mapPlatformShEnvironment;
+use const Platformsh\FlexBridge\DEFAULT_MARIADB_VERSION;
+use const Platformsh\FlexBridge\DEFAULT_MYSQL_VERSION;
+use const Platformsh\FlexBridge\DEFAULT_POSTGRESQL_VERSION;
 
 class FlexBridgeDatabaseTest extends TestCase
 {
@@ -81,18 +84,6 @@ class FlexBridgeDatabaseTest extends TestCase
         $this->assertArrayNotHasKey('DATABASE_URL', $_SERVER);
     }
 
-    public function testDatabaseRelationshipSet() : void
-    {
-        putenv('PLATFORM_APPLICATION_NAME=test');
-        putenv('PLATFORM_ENVIRONMENT=test');
-        putenv('PLATFORM_PROJECT_ENTROPY=test');
-        putenv('PLATFORM_SMTP_HOST=1.2.3.4');
-        putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($this->relationships))));
-
-        mapPlatformShEnvironment();
-        $this->assertEquals('mysql://user:@database.internal:3306/main?charset=utf8mb4&serverVersion=mariadb-10.2.12', $_SERVER['DATABASE_URL']);
-    }
-
     public function testDatabaseRelationshipOnFoundation1() : void
     {
         putenv('PLATFORM_APPLICATION_NAME=test');
@@ -112,4 +103,99 @@ class FlexBridgeDatabaseTest extends TestCase
         $this->assertEquals('mysql://user:@database.internal:3306/main?charset=utf8mb4&serverVersion=mariadb-10.2.12', $_SERVER['DATABASE_URL']);
     }
 
+    /**
+     * @dataProvider databaseVersionsProvider
+     */
+    public function testDatabaseRelationshipFormatters(string $type, string $scheme, string $expected) : void
+    {
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
+        putenv('PLATFORM_PROJECT_ENTROPY=test');
+        putenv('PLATFORM_SMTP_HOST=1.2.3.4');
+
+        $rels = $this->relationships;
+
+        $rels['database'][0]['type'] = $type;
+        $rels['database'][0]['scheme'] = $scheme;
+
+        putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($rels))));
+
+        mapPlatformShEnvironment();
+
+        $this->assertEquals($expected, $_SERVER['DATABASE_URL']);
+    }
+
+    /**
+     * @dataProvider databaseVersionsProvider
+     */
+    public function testDatabaseRelationshipFormattersFoundationV1(string $type, string $scheme, string $expected) : void
+    {
+        putenv('PLATFORM_APPLICATION_NAME=test');
+        putenv('PLATFORM_ENVIRONMENT=test');
+        putenv('PLATFORM_PROJECT_ENTROPY=test');
+        putenv('PLATFORM_SMTP_HOST=1.2.3.4');
+
+        $rels = $this->relationships;
+
+        $rels['database'][0]['scheme'] = $scheme;
+
+        // On Foundation 1, there is no `type` property.  Therefore we do not know what the DB version
+        // should be.  So we fall back to the default guesses and hope. If someone wants to use a different
+        // version, they should move to Foundation 3.
+        unset($rels['database'][0]['type']);
+        switch ($scheme) {
+            case 'mysql':
+                $default = 'mariadb-' . DEFAULT_MARIADB_VERSION . '.12';
+                break;
+            case 'pgsql':
+                $default = DEFAULT_POSTGRESQL_VERSION;
+        }
+        $expected = preg_replace('/serverVersion=.+$/', 'serverVersion=' . $default, $expected);
+
+        putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($rels))));
+
+        mapPlatformShEnvironment();
+
+        $this->assertEquals($expected, $_SERVER['DATABASE_URL']);
+    }
+
+
+    public function databaseVersionsProvider() : iterable
+    {
+        yield 'postgresql 9.6' => [
+            'type' => 'postgresql:9.6',
+            'scheme' => 'pgsql',
+            'expected' => 'pgsql://user:@database.internal:3306/main?serverVersion=9.6',
+        ];
+        yield 'postgresql 10' => [
+            'type' => 'postgresql:10',
+            'scheme' => 'pgsql',
+            'expected' => 'pgsql://user:@database.internal:3306/main?serverVersion=10',
+        ];
+
+        // This is the oddball that doesn't have a .0, because reasons.
+        yield 'mariadb 10.2' => [
+            'type' => 'mariadb:10.2',
+            'scheme' => 'mysql',
+            'expected' => 'mysql://user:@database.internal:3306/main?charset=utf8mb4&serverVersion=mariadb-10.2.12',
+        ];
+
+        yield 'mariadb 10.4' => [
+            'type' => 'mariadb:10.4',
+            'scheme' => 'mysql',
+            'expected' => 'mysql://user:@database.internal:3306/main?charset=utf8mb4&serverVersion=mariadb-10.4.0',
+        ];
+
+        yield 'mariadb 10.2 aliased' => [
+            'type' => 'mysql:10.2',
+            'scheme' => 'mysql',
+            'expected' => 'mysql://user:@database.internal:3306/main?charset=utf8mb4&serverVersion=mariadb-10.2.12',
+        ];
+
+        yield 'mysql 8' => [
+            'type' => 'oracle-mysql:8.0',
+            'scheme' => 'mysql',
+            'expected' => 'mysql://user:@database.internal:3306/main?charset=utf8mb4&serverVersion=8.0',
+        ];
+    }
 }

--- a/tests/FlexBridgeDatabaseTest.php
+++ b/tests/FlexBridgeDatabaseTest.php
@@ -84,25 +84,6 @@ class FlexBridgeDatabaseTest extends TestCase
         $this->assertArrayNotHasKey('DATABASE_URL', $_SERVER);
     }
 
-    public function testDatabaseRelationshipOnFoundation1() : void
-    {
-        putenv('PLATFORM_APPLICATION_NAME=test');
-        putenv('PLATFORM_ENVIRONMENT=test');
-        putenv('PLATFORM_PROJECT_ENTROPY=test');
-        putenv('PLATFORM_SMTP_HOST=1.2.3.4');
-
-        $rels = $this->relationships;
-
-        // On Foundation 1 regions there is no `type` key, so make sure nothing dies.
-        unset($rels['database'][0]['type']);
-
-        putenv(sprintf('PLATFORM_RELATIONSHIPS=%s', base64_encode(json_encode($rels))));
-
-        mapPlatformShEnvironment();
-
-        $this->assertEquals('mysql://user:@database.internal:3306/main?charset=utf8mb4&serverVersion=mariadb-10.2.12', $_SERVER['DATABASE_URL']);
-    }
-
     /**
      * @dataProvider databaseVersionsProvider
      */


### PR DESCRIPTION
This PR:

* Gets rid of the old hacks to derive the version for Doctrine.
* Introduces newer, more robust hacks to derive the version.
* Handles the difference between MySQL and MariaDB now that we offer both.
* Makes the code a lot simpler along the way.
* Greatly improves the test structure.

This needs testing on a real Symfony application.  It seems logical and all the tests pass, but I don't want to merge until it's been vetted in a real application.  Testers welcome!

Resolves #29 