### PR TITLE
Hack MariaDB version (required by doctrine)

### DIFF
--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -136,6 +136,8 @@ function doctrineFormatter(array $credentials) : string
             // if MariaDB is in version 10.2, doctrine needs to know it's superior to patch version 6 to work properly
             if ($dbVersion === 'mariadb-10.2') {
                 $dbVersion .= '.12';
+            } else {
+                $dbVersion .= '.0';
             }
 
             $dbUrl .= sprintf('?charset=utf8mb4&serverVersion=%s', $dbVersion);

--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -137,6 +137,8 @@ function doctrineFormatter(array $credentials) : string
             if ($dbVersion === 'mariadb-10.2') {
                 $dbVersion .= '.12';
             } else {
+                // Doctrine requires a .z in the version number, but that cannot be detected at runtime.
+                // Hard code a 0 because for everything except MariaDB 10.2, it doesn't actually matter.
                 $dbVersion .= '.0';
             }
 


### PR DESCRIPTION
Tested following MariaDB versions on https://github.com/ezsystems/ezplatform/releases/tag/v3.0.0-beta5:
- 10.0
- 10.1
- 10.3
- 10.4