### PR TITLE
Upgrade the operator for PHP version constraint and the PHPUnit version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
+.phpunit.result.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.1",
         "platformsh/config-reader": "^2.1.0"
     },
     "autoload": {
@@ -27,6 +27,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.4"
+        "phpunit/phpunit": "^8.5"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
     backupGlobals="true"
     backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"

--- a/tests/FlexBridgeDatabaseTest.php
+++ b/tests/FlexBridgeDatabaseTest.php
@@ -15,7 +15,7 @@ class FlexBridgeDatabaseTest extends TestCase
     protected $relationships;
     protected $defaultDbUrl;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This is a PR to allow the installation with PHP 8.0.
I haven't changed the CircleCI configuration, but the tests are also green on this version.