### PR TITLE
Support multiple database relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ composer require platformsh/symfonyflex-bridge
 
 * If a Platform.sh relationship named `database` is defined, it will be taken as an SQL database and mapped to the `DATABASE_URL` environment variable for Symfony Flex.  (Note: Due to a bug in Doctrine, the code currently assumes MariaDB 10.2 as the service version.  If that Doctrine bug is ever resolved this hard-coding can be removed.)
 
+* If you wish to map multiple database relationships, they can be defined as a comma-separated string (e.g `database,database_legacy`) in a `DATABASE_RELATIONSHIPS` environment variable within your Platform.sh environment. These will be mapped to environment variables named by uppercasing the relationship name and appending `_URL` (e.g., the `database_legacy` relationship would be mapped to the `DATABASE_LEGACY_URL` environment variable.)
+
 * The Symfony Flex `APP_SECRET` is set based on the `PLATFORM_PROJECT_ENTROPY` variable, which is provided for exactly this purpose.
 
 * The `MAILER_URL` variable is set based on the `PLATFORM_SMTP_HOST` variable.  That will be used by SwiftMailer if it is installed.  If not installed this value will be safely ignored.
@@ -95,7 +97,7 @@ search_engine_solr:
 
 ## Redis Cache
 
-If a Platform.sh relationship named `rediscache` is defined, it will be taken as a the storage engine for a cache pool. 
+If a Platform.sh relationship named `rediscache` is defined, it will be taken as a the storage engine for a cache pool.
 
 For typical use you will need to define a file looking like this:
 

--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -48,7 +48,6 @@ function mapPlatformShEnvironment() : void
     $appEnv = getenv('APP_ENV') ?: 'prod';
     setEnvVar('APP_ENV', $appEnv);
 
-
     // Map services as feasible.
     foreach (getDatabaseRelationships() as $relationship) {
         mapPlatformShDatabase($relationship, $config);


### PR DESCRIPTION
We have a client site on Platform.sh that has two databases - our primary Symfony database, and a legacy Drupal 7 database which is mostly used as a legacy data storage / migration source.

Currently, the Symfony Flex bridge only automatically configures a single `database` relationship into the `DATABASE_URL` environment variable.

This PR adds some flexibility - you can now define a `DATABASE_RELATIONSHIPS` environment variable in your Platform.sh environment that lists one or more database relationships to be configured. If this variable is not provided, the `database` relationship is still attempted by default, similar to the current behaviour.

Each relationship is then mapped to a `<RELATIONSHIP_NAME>_URL` environment variable named by taking the relationship name, uppercasing it, and appending `_URL'. For example, a `database_legacy` relationship would be mapped to a `DATABASE_LEGACY_URL` environment variable.

I've also included updates to the README to document the added functionality.
