### PR TITLE
Remove dependency on `rel` property

### DIFF
--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -320,7 +320,12 @@ function mapPlatformShSolr(string $relationshipName, Config $config): void
     $credentials = $config->credentials($relationshipName);
 
     setEnvVar('SOLR_DSN', sprintf('http://%s:%d/solr', $credentials['host'], $credentials['port']));
-    setEnvVar('SOLR_CORE', $credentials['rel']);
+    
+    if(isset($credentials['rel'])) {
+        setEnvVar('SOLR_CORE', $credentials['rel']);
+    } else {
+        setEnvVar('SOLR_CORE', substr($credentials['path'], 5)); // 'path' will have `solr/core`, we want to extract `core`
+    }
 }
 
 /**


### PR DESCRIPTION
Solr relationships don't always have a `rel` property. 

Documentation does mention that it looks like this:
Relationship 

The format exposed in the $PLATFORM_RELATIONSHIPS environment variable:
```
{
    "service": "solr86",
    "ip": "169.254.251.226",
    "hostname": "csjsvtdhmjrdre2uaoeim22xjy.solr86.service._.eu-3.platformsh.site",
    "cluster": "rjify4yjcwxaa-master-7rqtwti",
    "host": "solr.internal",
    "rel": "solr",
    "path": "solr\/maincore",
    "scheme": "solr",
    "type": "solr:8.6",
    "port": 8080
}
```

But sometimes it looks like this:
```
   "solr" : [
      {
         "port" : "8983",
         "path" : "solr/wb",
         "host" : "localhost",
         "scheme" : "solr"
      }
   ],
```
So lets check if 'rel' actually exists first. 
if it does not, extract the CORE from the path.

This is actually mentioned in the documentation https://docs.platform.sh/configuration/services/solr.html#solr-6-and-later but it also seems that way on dedicated instances.

