### PR TITLE
fix DSN in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For typical use you will need to define a file looking like this:
 ```yaml
 #config/packages/cache_pool/cache.redis.yaml
 parameters:
-    cache_dsn: '%env(CACHE_DSN)%'
+    cache_dsn: 'redis://%env(CACHE_DSN)%'
 
 services:
     cache.redis:


### PR DESCRIPTION
In Symfony a DSN for redis MUST have a scheme "redis" or "rediss" 

See
https://github.com/symfony/cache/blob/f438567393ae201263ace9951f8f89e219eb9712/Adapter/AbstractAdapter.php#L127

