### PR TITLE
Add ELASTICSEARCH_URL, CACHE_URL, SESSION_REDIS_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,20 +95,18 @@ search_engine_solr:
 
 ## Redis Cache
 
-If a Platform.sh relationship named `rediscache` is defined, it will be taken as a the storage engine for a cache pool. 
+If a Platform.sh relationship named `rediscache` is defined, it will be taken as a the storage engine for a cache pool.
 
 For typical use you will need to define a file looking like this:
 
 ```yaml
-#config/packages/cache_pool/cache.redis.yaml
-parameters:
-    cache_dsn: '%env(CACHE_DSN)%'
+# config/packages/framework.yaml
+framework:
+    cache:
+        app: cache.adapter.redis
+        system: cache.adapter.redis
+        default_redis_provider: "%env(CACHE_URL)%"
 
-services:
-    cache.redis:
-        public: true
-        class: Symfony\Component\Cache\Adapter\RedisTagAwareAdapter
-        parent: cache.adapter.redis
 ```
 For more details see [here](https://symfony.com/doc/current/components/cache/adapters/redis_adapter.html)
 
@@ -118,25 +116,11 @@ If a Platform.sh relationship named `redissession` is defined, it will be taken 
 
 For typical use you will need to add a couple of service definitions which looks like this:
 ```yaml
-# config/services.yaml
-services:
-    # ...
-    Redis:
-        class: Redis
-        calls:
-            - connect:
-                - '%env(SESSION_REDIS_HOST)%'
-                - '%env(int:SESSION_REDIS_PORT)%'
-    Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler:
-        arguments:
-            - '@Redis'
-```
-Then to configure symfony to use the new redis handler
-```yaml
 # config/packages/framework.yaml
 framework:
     session:
-        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler
+        handler_id: '%env(SESSION_REDIS_URL)%'
 ```
+
 
 For more details see [here](https://symfony.com/doc/current/session/database.html#store-sessions-in-a-key-value-database-redis)

--- a/platformsh-flex-env.php
+++ b/platformsh-flex-env.php
@@ -303,6 +303,7 @@ function mapPlatformShElasticSearch(string $relationshipName, Config $config): v
 
     setEnvVar('ELASTICSEARCH_HOST', $credentials['host']);
     setEnvVar('ELASTICSEARCH_PORT', (string)$credentials['port']);
+    setEnvVar('ELASTICSEARCH_URL', sprintf('http://%s:%s', $credentials['host'], (string) $credentials['port']));
 }
 
 /**
@@ -320,7 +321,7 @@ function mapPlatformShSolr(string $relationshipName, Config $config): void
     $credentials = $config->credentials($relationshipName);
 
     setEnvVar('SOLR_DSN', sprintf('http://%s:%d/solr', $credentials['host'], $credentials['port']));
-    
+
     if(isset($credentials['rel'])) {
         setEnvVar('SOLR_CORE', $credentials['rel']);
     } else {
@@ -344,6 +345,7 @@ function mapPlatformShRedisSession(string $relationshipName, Config $config): vo
 
     setEnvVar('SESSION_REDIS_HOST', $credentials['host']);
     setEnvVar('SESSION_REDIS_PORT', (string)$credentials['port']);
+    setEnvVar('SESSION_REDIS_URL', sprintf('redis://%s:%s', $credentials['host'], (string) $credentials['port']));
 }
 
 /**
@@ -361,4 +363,5 @@ function mapPlatformShRedisCache(string $relationshipName, Config $config): void
     $credentials = $config->credentials($relationshipName);
 
     setEnvVar('CACHE_DSN', sprintf('%s:%d', $credentials['host'], $credentials['port']));
+    setEnvVar('CACHE_URL', sprintf('redis://%s:%s', $credentials['host'], (string) $credentials['port']));
 }

--- a/tests/FlexBridgeElasticsearchTest.php
+++ b/tests/FlexBridgeElasticsearchTest.php
@@ -40,6 +40,7 @@ class FlexBridgeElasticsearchTest extends TestCase
 
         $this->assertArrayNotHasKey('ELASTICSEARCH_HOST', $_SERVER);
         $this->assertArrayNotHasKey('ELASTICSEARCH_PORT', $_SERVER);
+        $this->assertArrayNotHasKey('ELASTICSEARCH_URL', $_SERVER);
     }
 
     public function testNoElasticsearchRelationship(): void
@@ -58,6 +59,7 @@ class FlexBridgeElasticsearchTest extends TestCase
 
         $this->assertArrayNotHasKey('ELASTICSEARCH_HOST', $_SERVER);
         $this->assertArrayNotHasKey('ELASTICSEARCH_PORT', $_SERVER);
+        $this->assertArrayNotHasKey('ELASTICSEARCH_URL', $_SERVER);
     }
 
     public function testElasticsearchRelationshipSet(): void
@@ -72,5 +74,6 @@ class FlexBridgeElasticsearchTest extends TestCase
 
         $this->assertEquals('elasticsearch.internal', $_SERVER['ELASTICSEARCH_HOST']);
         $this->assertEquals(80, $_SERVER['ELASTICSEARCH_PORT']);
+        $this->assertEquals('http://elasticsearch.internal:80', $_SERVER['ELASTICSEARCH_URL']);
     }
 }

--- a/tests/FlexBridgeRedisCacheTest.php
+++ b/tests/FlexBridgeRedisCacheTest.php
@@ -20,7 +20,7 @@ class FlexBridgeRedisCacheTest extends TestCase
         $this->relationships = [
             "rediscache" => [
                 [
-                    
+
                     "service" => 'rediscache',
                     "ip" => "203.0.113.0",
                     "cluster" => "someCluster",
@@ -28,7 +28,7 @@ class FlexBridgeRedisCacheTest extends TestCase
                     "rel" => "rediscache",
                     "scheme" => "redis",
                     "port" => 6379
-                    
+
                 ]
             ]
         ];
@@ -40,6 +40,7 @@ class FlexBridgeRedisCacheTest extends TestCase
         mapPlatformShEnvironment();
 
         $this->assertArrayNotHasKey('CACHE_DSN', $_SERVER);
+        $this->assertArrayNotHasKey('CACHE_URL', $_SERVER);
     }
 
     public function testNoRedisRelationship(): void
@@ -56,6 +57,7 @@ class FlexBridgeRedisCacheTest extends TestCase
         mapPlatformShEnvironment();
 
         $this->assertArrayNotHasKey('CACHE_DSN', $_SERVER);
+        $this->assertArrayNotHasKey('CACHE_URL', $_SERVER);
         $this->assertArrayNotHasKey('SESSION_REDIS_HOST', $_SERVER);
         $this->assertArrayNotHasKey('SESSION_REDIS_PORT', $_SERVER);
     }
@@ -73,5 +75,6 @@ class FlexBridgeRedisCacheTest extends TestCase
         mapPlatformShEnvironment();
 
         $this->assertEquals('rediscache.internal:6379', $_SERVER['CACHE_DSN']);
+        $this->assertEquals('redis://rediscache.internal:6379', $_SERVER['CACHE_URL']);
     }
 }

--- a/tests/FlexBridgeRedisSessionTest.php
+++ b/tests/FlexBridgeRedisSessionTest.php
@@ -20,7 +20,7 @@ class FlexBridgeSessionTest extends TestCase
         $this->relationships = [
             "redissession" => [
                 [
-                    
+
                     "service" => 'redissession',
                     "ip" => "203.0.113.0",
                     "cluster" => "someCluster",
@@ -28,7 +28,7 @@ class FlexBridgeSessionTest extends TestCase
                     "rel" => "redissession",
                     "scheme" => "redis",
                     "port" => 6379
-                    
+
                 ]
             ]
         ];
@@ -41,6 +41,7 @@ class FlexBridgeSessionTest extends TestCase
 
         $this->assertArrayNotHasKey('SESSION_REDIS_HOST', $_SERVER);
         $this->assertArrayNotHasKey('SESSION_REDIS_PORT', $_SERVER);
+        $this->assertArrayNotHasKey('SESSION_REDIS_URL', $_SERVER);
     }
 
     public function testNoRedisRelationship(): void
@@ -58,6 +59,7 @@ class FlexBridgeSessionTest extends TestCase
 
         $this->assertArrayNotHasKey('SESSION_REDIS_HOST', $_SERVER);
         $this->assertArrayNotHasKey('SESSION_REDIS_PORT', $_SERVER);
+        $this->assertArrayNotHasKey('SESSION_REDIS_URL', $_SERVER);
     }
 
     public function testRelationshipSession(): void
@@ -74,5 +76,6 @@ class FlexBridgeSessionTest extends TestCase
 
         $this->assertEquals('redissession.internal', $_SERVER['SESSION_REDIS_HOST']);
         $this->assertEquals('6379', $_SERVER['SESSION_REDIS_PORT']);
+        $this->assertEquals('redis://redissession.internal:6379', $_SERVER['SESSION_REDIS_URL']);
     }
 }


### PR DESCRIPTION
This PR introduces three new env
- `ELASTICSEARCH_URL` - Like in other PaaS solutions
- `SESSION_REDIS_URL` - Just pass it to Symfony, and it does anything by own
- `CACHE_URL` - Just pass it to Symfony, and it does anything by own

See README for example usages